### PR TITLE
Add option to use internal CA for local auth endpoint

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -1000,6 +1000,7 @@ see more information on [Resource Management for Pods and Containers](https://ku
 * `enabled` - (Optional, bool, default: false) Enable the authorized cluster endpoint.
 * `fqdn` - (Optional, string) FQDN for the authorized cluster endpoint. If one is entered, it should point to the downstream cluster.
 * `ca_certs` - (Optional, string) CA certs for the authorized cluster endpoint. It is only needed if there is a load balancer in front of the downstream cluster that is using an untrusted certificate. If you have a valid certificate, then nothing needs to be added to the CA Certificates field.
+* `use_internal_ca_certs` - (Optional, bool, default: false) Use the cluster's internally generated CA certificates for the authorized cluster endpoint. Conflicts with `ca_certs`.
 
 #### `upgrade_strategy`
 

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -1000,7 +1000,7 @@ see more information on [Resource Management for Pods and Containers](https://ku
 * `enabled` - (Optional, bool, default: false) Enable the authorized cluster endpoint.
 * `fqdn` - (Optional, string) FQDN for the authorized cluster endpoint. If one is entered, it should point to the downstream cluster.
 * `ca_certs` - (Optional, string) CA certs for the authorized cluster endpoint. It is only needed if there is a load balancer in front of the downstream cluster that is using an untrusted certificate. If you have a valid certificate, then nothing needs to be added to the CA Certificates field.
-* `use_internal_ca_certs` - (Optional, bool, default: false) Use the cluster's internally generated CA certificates for the authorized cluster endpoint. Conflicts with `ca_certs`.
+* `use_internal_ca_certs` - (Optional, bool, default: false) Use the cluster's internally generated CA certificates for the authorized cluster endpoint. Conflicts with `ca_certs`. When enabled, the provider automatically retrieves the certificates from the cluster.
 
 #### `upgrade_strategy`
 

--- a/rancher2/resource_rancher2_cluster_v2.go
+++ b/rancher2/resource_rancher2_cluster_v2.go
@@ -496,7 +496,7 @@ func getClusterCACert(c *Config, clusterV1ID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return cluster.CACert, nil
+	return decodeCACertIfBase64(cluster.CACert), nil
 }
 
 func setClusterV2LocalAuthEndpointInternalFlag(d *schema.ResourceData, c *Config, cluster *ClusterV2) error {

--- a/rancher2/resource_rancher2_cluster_v2.go
+++ b/rancher2/resource_rancher2_cluster_v2.go
@@ -51,6 +51,13 @@ func resourceRancher2ClusterV2() *schema.Resource {
 				oldInterface, oldOk := oldObj.([]interface{})
 				newInterface, newOk := newObj.([]interface{})
 				if oldOk && newOk && len(newInterface) > 0 {
+					if m, ok := newInterface[0].(map[string]interface{}); ok {
+						if ca, ok := m["ca_certs"].(string); ok && ca != "" {
+							if use, ok := m["use_internal_ca_certs"].(bool); ok && use {
+								return fmt.Errorf("only one of \"ca_certs\" or \"use_internal_ca_certs\" can be set")
+							}
+						}
+					}
 					oldConfig := expandClusterV2LocalAuthEndpoint(oldInterface)
 					newConfig := expandClusterV2LocalAuthEndpoint(newInterface)
 					oldUse := false

--- a/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
+++ b/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
@@ -9,9 +9,8 @@ import (
 func clusterV2LocalAuthEndpointFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"ca_certs": {
-			Type:          schema.TypeString,
-			Optional:      true,
-			ConflictsWith: []string{"use_internal_ca_certs"},
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"enabled": {
 			Type:     schema.TypeBool,
@@ -23,10 +22,9 @@ func clusterV2LocalAuthEndpointFields() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"use_internal_ca_certs": {
-			Type:          schema.TypeBool,
-			Optional:      true,
-			Default:       false,
-			ConflictsWith: []string{"ca_certs"},
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
 		},
 	}
 

--- a/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
+++ b/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
@@ -9,8 +9,9 @@ import (
 func clusterV2LocalAuthEndpointFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"ca_certs": {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:          schema.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{"use_internal_ca_certs"},
 		},
 		"enabled": {
 			Type:     schema.TypeBool,
@@ -20,6 +21,12 @@ func clusterV2LocalAuthEndpointFields() map[string]*schema.Schema {
 		"fqdn": {
 			Type:     schema.TypeString,
 			Optional: true,
+		},
+		"use_internal_ca_certs": {
+			Type:          schema.TypeBool,
+			Optional:      true,
+			Default:       false,
+			ConflictsWith: []string{"ca_certs"},
 		},
 	}
 

--- a/rancher2/structure_cluster_v2_local_auth_endpoint_test.go
+++ b/rancher2/structure_cluster_v2_local_auth_endpoint_test.go
@@ -11,6 +11,7 @@ var (
 	testClusterV2LocalAuthEndpointConf                 rkev1.LocalClusterAuthEndpoint
 	testClusterV2LocalAuthEndpointInterface            []interface{}
 	testClusterV2LocalAuthEndpointInterfaceUseInternal []interface{}
+	testClusterV2LocalAuthEndpointInterfaceWithFlag    []interface{}
 )
 
 func init() {
@@ -33,6 +34,14 @@ func init() {
 			"enabled":               true,
 			"fqdn":                  "fqdn",
 			"use_internal_ca_certs": true,
+		},
+	}
+	testClusterV2LocalAuthEndpointInterfaceWithFlag = []interface{}{
+		map[string]interface{}{
+			"ca_certs":              "ca_certs",
+			"enabled":               true,
+			"fqdn":                  "fqdn",
+			"use_internal_ca_certs": false,
 		},
 	}
 }

--- a/rancher2/structure_cluster_v2_local_auth_endpoint_test.go
+++ b/rancher2/structure_cluster_v2_local_auth_endpoint_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	testClusterV2LocalAuthEndpointConf      rkev1.LocalClusterAuthEndpoint
-	testClusterV2LocalAuthEndpointInterface []interface{}
+	testClusterV2LocalAuthEndpointConf                 rkev1.LocalClusterAuthEndpoint
+	testClusterV2LocalAuthEndpointInterface            []interface{}
+	testClusterV2LocalAuthEndpointInterfaceUseInternal []interface{}
 )
 
 func init() {
@@ -24,6 +25,14 @@ func init() {
 			"ca_certs": "ca_certs",
 			"enabled":  true,
 			"fqdn":     "fqdn",
+		},
+	}
+	testClusterV2LocalAuthEndpointInterfaceUseInternal = []interface{}{
+		map[string]interface{}{
+			"ca_certs":              "ca_certs",
+			"enabled":               true,
+			"fqdn":                  "fqdn",
+			"use_internal_ca_certs": true,
 		},
 	}
 }
@@ -53,7 +62,7 @@ func TestExpandClusterV2LocalAuthEndpoint(t *testing.T) {
 		ExpectedOutput rkev1.LocalClusterAuthEndpoint
 	}{
 		{
-			testClusterV2LocalAuthEndpointInterface,
+			testClusterV2LocalAuthEndpointInterfaceUseInternal,
 			testClusterV2LocalAuthEndpointConf,
 		},
 	}

--- a/rancher2/structure_cluster_v2_test.go
+++ b/rancher2/structure_cluster_v2_test.go
@@ -232,7 +232,7 @@ func init() {
 		"name":                                   "name",
 		"fleet_namespace":                        "fleet_namespace",
 		"kubernetes_version":                     "kubernetes_version",
-		"local_auth_endpoint":                    testClusterV2LocalAuthEndpointInterface,
+		"local_auth_endpoint":                    testClusterV2LocalAuthEndpointInterfaceWithFlag,
 		"rke_config":                             testClusterV2RKEConfigInterface,
 		"agent_env_vars":                         testClusterV2EnvVarInterface,
 		"cluster_agent_deployment_customization": testClusterV2ClusterAgentCustomizationInterface,

--- a/rancher2/structure_cluster_v2_test.go
+++ b/rancher2/structure_cluster_v2_test.go
@@ -232,7 +232,7 @@ func init() {
 		"name":                                   "name",
 		"fleet_namespace":                        "fleet_namespace",
 		"kubernetes_version":                     "kubernetes_version",
-		"local_auth_endpoint":                    testClusterV2LocalAuthEndpointInterfaceWithFlag,
+		"local_auth_endpoint":                    testClusterV2LocalAuthEndpointInterface,
 		"rke_config":                             testClusterV2RKEConfigInterface,
 		"agent_env_vars":                         testClusterV2EnvVarInterface,
 		"cluster_agent_deployment_customization": testClusterV2ClusterAgentCustomizationInterface,

--- a/rancher2/util_certs.go
+++ b/rancher2/util_certs.go
@@ -1,0 +1,13 @@
+package rancher2
+
+import "encoding/base64"
+
+func decodeCACertIfBase64(cert string) string {
+	if cert == "" {
+		return cert
+	}
+	if b, err := base64.StdEncoding.DecodeString(cert); err == nil {
+		return string(b)
+	}
+	return cert
+}

--- a/rancher2/util_certs_test.go
+++ b/rancher2/util_certs_test.go
@@ -1,0 +1,17 @@
+package rancher2
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestDecodeCACertIfBase64(t *testing.T) {
+	pem := "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+	encoded := base64.StdEncoding.EncodeToString([]byte(pem))
+	if got := decodeCACertIfBase64(encoded); got != pem {
+		t.Fatalf("expected decoded cert, got %q", got)
+	}
+	if got := decodeCACertIfBase64(pem); got != pem {
+		t.Fatalf("expected unchanged cert, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- allow using internally generated CA certificates for cluster v2 local auth endpoint
- document and test `use_internal_ca_certs` option

## Testing
- `go test ./rancher2 -run TestExpandClusterV2LocalAuthEndpoint -count=1 -v` *(failed: command hung, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a08e9e59708323837e31285b87486c