### PR TITLE
Mark ca_certs field as computed

### DIFF
--- a/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
+++ b/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
@@ -11,6 +11,7 @@ func clusterV2LocalAuthEndpointFields() map[string]*schema.Schema {
 		"ca_certs": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Computed: true,
 		},
 		"enabled": {
 			Type:     schema.TypeBool,


### PR DESCRIPTION
## Summary
- mark `ca_certs` as Computed so it remains stable in state

## Testing
- `go test ./rancher2 -run TestExpandClusterV2LocalAuthEndpoint -count=1 -v`
- `make test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68a0dda050488323888e535d7bea9b1a